### PR TITLE
Mark tests as “Integration” group

### DIFF
--- a/src/test/java/io/cloudsoft/dbaccess/MySqlDatabaseAccessEntityIntegrationTest.java
+++ b/src/test/java/io/cloudsoft/dbaccess/MySqlDatabaseAccessEntityIntegrationTest.java
@@ -43,14 +43,14 @@ public class MySqlDatabaseAccessEntityIntegrationTest extends AbstractDatabaseAc
         super.tearDown();
     }
 
-    @Test()
+    @Test(groups="Integration")
     public void testNoPasswordProvided() throws Exception {
         EntitySpec<MySqlDatabaseAccessEntity> spec = EntitySpec.create(MySqlDatabaseAccessEntity.class);
         MySqlDatabaseAccessEntity entity = createDatabaseAccessEntity(spec);
         runTest(entity);
     }
 
-    @Test()
+    @Test(groups="Integration")
     public void testWithPasswordProvided() throws Exception {
         EntitySpec<MySqlDatabaseAccessEntity> spec = EntitySpec.create(MySqlDatabaseAccessEntity.class)
                 .configure(DatabaseAccessEntity.USERNAME, TEST_USERNAME)

--- a/src/test/java/io/cloudsoft/dbaccess/PostgresDatabaseAccessEntityIntegrationTest.java
+++ b/src/test/java/io/cloudsoft/dbaccess/PostgresDatabaseAccessEntityIntegrationTest.java
@@ -26,14 +26,14 @@ public class PostgresDatabaseAccessEntityIntegrationTest extends AbstractDatabas
         super.tearDown();
     }
 
-    @Test()
+    @Test(groups="Integration")
     public void testNoPasswordProvided() throws Exception {
         EntitySpec<PostgresDatabaseAccessEntity> spec = EntitySpec.create(PostgresDatabaseAccessEntity.class);
         PostgresDatabaseAccessEntity entity = createDatabaseAccessEntity(spec);
         runTest(entity);
     }
 
-    @Test()
+    @Test(groups="Integration")
     public void testWithPasswordProvided() throws Exception  {
         EntitySpec<PostgresDatabaseAccessEntity> spec = EntitySpec.create(PostgresDatabaseAccessEntity.class)
                 .configure(DatabaseAccessEntity.USERNAME, TEST_USERNAME)


### PR DESCRIPTION
Tests that include provisioning a DB must be marked as “Integration”, to be consistent with the other brooklyn downstream repos.
