### PR TITLE
Change version to 0.2.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>io.cloudsoft.dbaccess</groupId>
     <artifactId>dbaccess</artifactId>
-    <version>0.1.0-SNAPSHOT</version> <!-- DBACCESS_VERSION -->
+    <version>0.2.0-SNAPSHOT</version> <!-- DBACCESS_VERSION -->
     <packaging>jar</packaging>
 
     <name>DBAccess</name>


### PR DESCRIPTION
Now that we've switched master to brooklyn 0.11.0-SNAPSHOT, we also need to bump the dbaccess-entity version number.

I've also create a 0.1.x branch, which depends on brooklyn 0.10.0-SNAPSHOT. We'll release 0.1.0 once brooklyn 0.10.0 is released.