### PR TITLE
Fixes due to upstream changes

### DIFF
--- a/src/main/java/io/cloudsoft/dbaccess/client/AbstractDatabaseAccessClient.java
+++ b/src/main/java/io/cloudsoft/dbaccess/client/AbstractDatabaseAccessClient.java
@@ -249,7 +249,7 @@ public abstract class AbstractDatabaseAccessClient implements DatabaseAccessClie
                     }
                 }
             } catch (SQLException e) {
-                throw Exceptions.propagate("Error executing SQL for "+description, e);
+                throw Exceptions.propagateAnnotated("Error executing SQL for "+description, e);
             }            
         }
         
@@ -335,7 +335,7 @@ public abstract class AbstractDatabaseAccessClient implements DatabaseAccessClie
         try {
             return DriverManager.getConnection(jdbcUrl);
         } catch (SQLException e) {
-            throw Exceptions.propagate(e);
+            throw Exceptions.propagate((Throwable) e);
         }
     }
 }


### PR DESCRIPTION
Exceptions.propagate(String, Throwable) has been deprecated in place of Exceptions.propagateAnnotated(String, Throwable).

Also a change was made upstream to propagate(Collection<? extends Throwable>). It is now propagate(Iterable<? extends Throwable>). This now clashes with propagate(Throwable) when trying to propagate a SQLException as SQLException implements both Iterable<? extends Throwable> and Throwable. So, we now cast SQLException to Throwable to ensure the correct method is called.
